### PR TITLE
Docs: fix llms.txt link casing

### DIFF
--- a/docs/docs/integrations/ai-agents.md
+++ b/docs/docs/integrations/ai-agents.md
@@ -7,11 +7,11 @@ sidebar_label: AI Agents
 
 ## LLM-friendly docs
 
-We publish `LLMs.txt` and `LLMs-full.txt` at the documentation root so agents can index the full docs quickly.
+We publish `llms.txt` and `llms-full.txt` at the documentation root so agents can index the full docs quickly.
 
 ```bash
-curl -L https://opensource.respawn.pro/FlowMVI/LLMs.txt
-curl -L https://opensource.respawn.pro/FlowMVI/LLMs-full.txt
+curl -L https://opensource.respawn.pro/FlowMVI/llms.txt
+curl -L https://opensource.respawn.pro/FlowMVI/llms-full.txt
 ```
 
 You can also fetch any doc page as markdown by appending `.md` to its URL, which makes `curl`-based discovery easy:


### PR DESCRIPTION
Fixes AI Agents docs to reference the published lowercase LLM index files (`llms.txt`, `llms-full.txt`).

GitHub Pages is case-sensitive:
- `https://opensource.respawn.pro/FlowMVI/LLMs.txt` → 404
- `https://opensource.respawn.pro/FlowMVI/llms.txt` → 200

Doc build check: `npm -C docs run build` generates `docs/build/llms.txt` and `docs/build/llms-full.txt`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated file references and curl commands in AI agents documentation to reflect standardized lowercase filename conventions.

* **Style**
  * Standardized naming conventions across documentation examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->