### PR TITLE
chore: update github actions deps

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "$LOCAL_PROPERTIES" | base64 --decode > local.properties
 
       - name: Cache konan directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('*.gradle.kts', 'buildSrc/*') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "$LOCAL_PROPERTIES" | base64 --decode > local.properties
 
       - name: Cache konan directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('*.gradle.kts', 'buildSrc/*') }}

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -42,7 +42,7 @@ jobs:
         run: echo "$LOCAL_PROPERTIES" | base64 --decode > local.properties
 
       - name: Cache konan directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('*.gradle.kts', 'buildSrc/*') }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload debugger
         id: upload-debugger
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v7
         with:
           name: Debugger_Linux
           path: ./debugger/app/build/compose/binaries/main/deb/*
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload sample
         id: upload-sample
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v7
         with:
           name: Sample_Linux
           path: ./sample/build/compose/binaries/main/deb/*

--- a/.github/workflows/desktop-macos.yml
+++ b/.github/workflows/desktop-macos.yml
@@ -42,7 +42,7 @@ jobs:
         run: echo "$LOCAL_PROPERTIES" | base64 --decode > local.properties
 
       - name: Cache konan directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('*.gradle.kts', 'buildSrc/*') }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload debugger
         id: upload-debugger
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v7
         with:
           name: Debugger_MacOS
           path: ./debugger/app/build/compose/binaries/main/dmg/*
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload sample
         id: upload-sample
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v7
         with:
           name: Sample_MacOS
           path: ./sample/build/compose/binaries/main/dmg/*

--- a/.github/workflows/desktop-win.yml
+++ b/.github/workflows/desktop-win.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "$LOCAL_PROPERTIES" | base64 --decode > local.properties
 
       - name: Cache konan directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('*.gradle.kts', 'buildSrc/*') }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload debugger
         id: upload-debugger
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v7
         with:
           name: Debugger_Windows
           path: ./debugger/app/build/compose/binaries/main/exe/*
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload sample
         id: upload-sample
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v7
         with:
           name: Sample_Windows
           path: ./sample/build/compose/binaries/main/exe/*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "$LOCAL_PROPERTIES" | base64 --decode > local.properties
 
       - name: Cache konan directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('*.gradle.kts', 'buildSrc/*') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
         run: echo "$LOCAL_PROPERTIES" | base64 --decode > local.properties
 
       - name: Cache konan directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('*.gradle.kts', 'buildSrc/*') }}


### PR DESCRIPTION
Summary:
- bump actions/cache from v4 to v5 across workflow jobs
- bump actions/upload-artifact from v5.0.0 to v7 in desktop workflows
- leave other workflow action refs unchanged where they already track the latest major or latest pinned release

Verification:
- git diff --check
- attempted ./gradlew detektFormat
- attempted ./gradlew allTests

Sandbox note: Gradle verification is blocked in this environment by restricted writes under user-level Kotlin/Gradle directories, so those runs could not be completed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment infrastructure with the latest versions of automated tools to maintain compatibility and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->